### PR TITLE
[#4] TTL 기반 단기기억 만료 항목 정리 기능 추가

### DIFF
--- a/brain_memory/gui/memory_gui.py
+++ b/brain_memory/gui/memory_gui.py
@@ -1,6 +1,6 @@
 import tkinter as tk
 from tkinter import ttk, messagebox
-from utils.memory_store import save_to_short_term
+from utils.memory_store import save_to_short_term, clean_expired_memory
 
 class MemoryGUI:
     def on_save(self):
@@ -12,6 +12,10 @@ class MemoryGUI:
         save_to_short_term(content)
         self.output_text.insert("end", f"[Saved] {content}\n")
         self.input_entry.delete(0, "end")
+
+    def on_clean_expired(self):
+        removed = clean_expired_memory()
+        self.output_text.insert("end", f"[Expired Removed] {removed} item(s) deleted\n")
 
     def __init__(self, root):
         self.root = root
@@ -33,6 +37,10 @@ class MemoryGUI:
         self.search_entry.pack(padx=10, pady=5)
         self.search_button = ttk.Button(self.search_frame, text="Search")
         self.search_button.pack(pady=5)
+
+        # TTL 정리 버튼
+        self.clean_button = ttk.Button(self.search_frame, text="Clean Expired", command=self.on_clean_expired)
+        self.clean_button.pack(pady=5)
 
         # 출력창 프레임
         self.output_frame = ttk.LabelFrame(root, text="Output")

--- a/brain_memory/utils/memory_store.py
+++ b/brain_memory/utils/memory_store.py
@@ -34,3 +34,23 @@ def save_to_short_term(content: str):
         json.dump(data, f, indent=4)
 
     print(f"Saved to short-term memory: {content}")
+
+def clean_expired_memory():
+    now = int(time.time())
+    removed = 0
+
+    if os.path.exists(SHORT_TERM_PATH):
+        with open(SHORT_TERM_PATH, "r", encoding="utf-8") as f:
+            try:
+                data = json.load(f)
+            except json.JSONDecodeError:
+                data = []
+
+        # 유효한 기억만 필터링
+        valid_data = [item for item in data if item["expire_at"] > now]
+        removed = len(data) - len(valid_data)
+
+        with open(SHORT_TERM_PATH, "w", encoding="utf-8") as f:
+            json.dump(valid_data, f, indent=4, ensure_ascii=False)
+
+    return removed


### PR DESCRIPTION
- 단기기억 JSON 파일(short_term.json)에 저장된 항목 중, 현재 시간보다 expire_at이 지난 항목을 제거하는 기능 추가
- GUI에 "Clean Expired" 버튼을 생성하여 클릭 시 만료 항목을 자동 정리
- 제거된 항목 수는 Output 영역에 출력되도록 구성
- clean_expired_memory() 함수는 memory_store.py에 위치

![image](https://github.com/user-attachments/assets/3918c473-47dc-47b4-b4d7-4d47b1200ab6)
