### PR TITLE
[#2] 단기 기억 인출 기능 구현 및 TTL 갱신 로직 추가

### DIFF
--- a/brain_memory/gui/memory_gui.py
+++ b/brain_memory/gui/memory_gui.py
@@ -1,6 +1,6 @@
 import tkinter as tk
 from tkinter import ttk, messagebox
-from utils.memory_store import save_to_short_term, clean_expired_memory
+from utils.memory_store import save_to_short_term, clean_expired_memory, search_and_update_count
 
 class MemoryGUI:
     def on_save(self):
@@ -12,6 +12,23 @@ class MemoryGUI:
         save_to_short_term(content)
         self.output_text.insert("end", f"[Saved] {content}\n")
         self.input_entry.delete(0, "end")
+
+    def on_search(self):
+        keyword = self.search_entry.get().strip()
+        if not keyword:
+            messagebox.showwarning("검색어를 입력해주세요.")
+            return
+
+        results = search_and_update_count(keyword)
+        self.output_text.insert("end", f"[Search] '{keyword}' 검색 결과:\n")
+
+        if results:
+            for item in results:
+                self.output_text.insert("end", f"- {item['content']} (count: {item['count']})\n")
+        else:
+            self.output_text.insert("end", "검색 결과 없음.\n")
+
+        self.search_entry.delete(0, "end")
 
     def on_clean_expired(self):
         removed = clean_expired_memory()
@@ -35,7 +52,7 @@ class MemoryGUI:
         self.search_frame.pack(fill="x", padx=10, pady=10)
         self.search_entry = ttk.Entry(self.search_frame, width=70)
         self.search_entry.pack(padx=10, pady=5)
-        self.search_button = ttk.Button(self.search_frame, text="Search")
+        self.search_button = ttk.Button(self.search_frame, text="Search", command=self.on_search)
         self.search_button.pack(pady=5)
 
         # TTL 정리 버튼

--- a/brain_memory/utils/memory_store.py
+++ b/brain_memory/utils/memory_store.py
@@ -9,6 +9,7 @@ DATA_DIR = os.path.join(BASE_DIR, "data")
 SHORT_TERM_PATH = os.path.join(DATA_DIR, "short_term.json")
 DEFAULT_TTL = 60
 
+# 단기기억 저장
 def save_to_short_term(content: str):
     now = int(time.time())
     expire_at = now + DEFAULT_TTL
@@ -35,6 +36,7 @@ def save_to_short_term(content: str):
 
     print(f"Saved to short-term memory: {content}")
 
+# 망각
 def clean_expired_memory():
     now = int(time.time())
     removed = 0
@@ -54,3 +56,31 @@ def clean_expired_memory():
             json.dump(valid_data, f, indent=4, ensure_ascii=False)
 
     return removed
+
+# 인출
+def search_and_update_count(keyword: str):
+    now = int(time.time())
+    results = []
+
+    if not os.path.exists(SHORT_TERM_PATH):
+        return results
+
+    with open(SHORT_TERM_PATH, "r", encoding="utf-8") as f:
+        try:
+            data = json.load(f)
+        except json.JSONDecodeError:
+            data = []
+
+    updated = False
+    for item in data:
+        if item["expire_at"] > now and keyword in item["content"]:
+            item["count"] += 1
+            item["expire_at"] = now + DEFAULT_TTL
+            results.append(item)
+            updated = True
+
+    if updated:
+        with open(SHORT_TERM_PATH, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=4, ensure_ascii=False)
+
+    return results


### PR DESCRIPTION
- 사용자로부터 검색어(keyword)를 입력받아 단기 기억에서 해당 내용을 검색
- 검색된 기억 항목의 count 값을 1 증가
- 해당 항목의 expire_at(TTL)을 현재 시각 기준으로 갱신하여 기억 유지 시간 연장
- 검색 결과는 GUI 출력창에 표시되며, 잊혀지기 직전의 기억도 인출을 통해 생존 가능
- 실제 뇌의 인출-강화 메커니즘을 모방한 설계