### PR TITLE
[#5] 임계치 이상의 인출 시 장기기억으로 이동 구

### DIFF
--- a/brain_memory/utils/memory_store.py
+++ b/brain_memory/utils/memory_store.py
@@ -7,6 +7,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 DATA_DIR = os.path.join(BASE_DIR, "data")
 
 SHORT_TERM_PATH = os.path.join(DATA_DIR, "short_term.json")
+LONG_TERM_PATH = os.path.join(DATA_DIR, "long_term.json")
 DEFAULT_TTL = 60
 
 # 단기기억 저장
@@ -61,6 +62,7 @@ def clean_expired_memory():
 def search_and_update_count(keyword: str):
     now = int(time.time())
     results = []
+    updated = False
 
     if not os.path.exists(SHORT_TERM_PATH):
         return results
@@ -71,16 +73,39 @@ def search_and_update_count(keyword: str):
         except json.JSONDecodeError:
             data = []
 
-    updated = False
+    new_data = []
     for item in data:
-        if item["expire_at"] > now and keyword in item["content"]:
-            item["count"] += 1
-            item["expire_at"] = now + DEFAULT_TTL
-            results.append(item)
-            updated = True
+        if item["expire_at"] > now:
+            if keyword in item["content"]:
+                item["count"] += 1
+                item["expire_at"] = now + DEFAULT_TTL
+                results.append(item)
+                updated = True
+
+                if item["count"] >= 4:
+                    save_to_long_term(item)
+                    print(f"[Long-Term] 기억 전환됨: {item['content']}")
+                    continue
+        new_data.append(item)
 
     if updated:
         with open(SHORT_TERM_PATH, "w", encoding="utf-8") as f:
-            json.dump(data, f, indent=4, ensure_ascii=False)
+            json.dump(new_data, f, indent=4, ensure_ascii=False)
 
     return results
+
+
+def save_to_long_term(item: dict):
+    if os.path.exists(LONG_TERM_PATH):
+        with open(LONG_TERM_PATH, "r", encoding="utf-8") as f:
+            try:
+                long_data = json.load(f)
+            except json.JSONDecodeError:
+                long_data = []
+    else:
+        long_data = []
+
+    long_data.append(item)
+
+    with open(LONG_TERM_PATH, "w", encoding="utf-8") as f:
+        json.dump(long_data, f, indent=4, ensure_ascii=False)


### PR DESCRIPTION
단기기억의 인출 횟수가 4회 이상이 되면 자동으로 장기기억으로 전환되는 기능을 구현.

변경 사항:
- `search_and_update_count()` 함수 내에서 count ≥ 4인 경우 `save_to_long_term()`을 호출하여 장기기억으로 이동
- 장기기억은 `long_term.json` 파일에 저장
- 전환 후에는 단기기억 리스트에서 해당 항목 제거
- TTL은 인출 시마다 갱신되며, 장기기억에는 TTL 미적용 (추후 기능 추가 가능)

향후 확장:
- 장기기억의 `last_accessed_at` 필드 추가 가능
- 일정 기간 미인출된 항목에 대한 망각 처리 로직 추가 고려

![image](https://github.com/user-attachments/assets/b6e2cade-e116-4c0c-8652-d60e2080988f)
